### PR TITLE
Revert `@openhw/emulator` dependency to the GitHub develop branch and…

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "@babel/standalone": "^7.29.1",
-    "@openhw/emulator": "file:../openhw-studio-emulator-danish",
+    "@openhw/emulator": "github:OpenHW-Studio/openhw-studio-emulator#develop",
     "@react-oauth/google": "^0.12.1",
     "@tailwindcss/postcss": "^4.2.1",
     "avr8js": "^0.21.0",

--- a/vite.config.js
+++ b/vite.config.js
@@ -15,12 +15,4 @@ export default defineConfig({
       ],
     },
   },
-  resolve: {
-    alias: {
-      // Use the local emulator source instead of the git-pinned npm package.
-      // This makes all component UI, ContextMenu, and logic changes immediately
-      // visible to the frontend without needing to push to git or reinstall.
-      '@openhw/emulator': path.resolve(__dirname, '../openhw-studio-emulator-danish'),
-    },
-  },
 })


### PR DESCRIPTION
… remove its local alias configuration.