### PR TITLE
Register logic gate components in simulation engine

### DIFF
--- a/src/worker/execute.ts
+++ b/src/worker/execute.ts
@@ -15,6 +15,18 @@ import { SlidePotLogic } from '@openhw/emulator/src/components/wokwi-slide-poten
 import { PotentiometerLogic } from '@openhw/emulator/src/components/wokwi-potentiometer/logic.ts';
 import { ShiftRegisterLogic } from '@openhw/emulator/src/components/shift_register/logic.ts';
 import { JoystickLogic } from '@openhw/emulator/src/components/wokwi-analog-joystick/logic.ts';
+import { NotGateLogic } from '@openhw/emulator/src/components/logic-not-gate/logic.ts';
+import { AndGateLogic } from '@openhw/emulator/src/components/logic-and-gate/logic.ts';
+import { OrGateLogic } from '@openhw/emulator/src/components/logic-or-gate/logic.ts';
+import { NorGateLogic } from '@openhw/emulator/src/components/logic-nor-gate/logic.ts';
+import { NandGateLogic } from '@openhw/emulator/src/components/logic-nand-gate/logic.ts';
+import { XorGateLogic } from '@openhw/emulator/src/components/logic-xor-gate/logic.ts';
+import { XnorGateLogic } from '@openhw/emulator/src/components/logic-xnor-gate/logic.ts';
+import { Mux2to1Logic } from '@openhw/emulator/src/components/logic-mux-2to1/logic.ts';
+import { DFlipFlopLogic } from '@openhw/emulator/src/components/logic-d-flipflop/logic.ts';
+import { DFlipFlopRLogic } from '@openhw/emulator/src/components/logic-d-flipflop-r/logic.ts';
+import { DFlipFlopDsrLogic } from '@openhw/emulator/src/components/logic-d-flipflop-dsr/logic.ts';
+import { ClockGeneratorLogic } from '@openhw/emulator/src/components/logic-clock-generator/logic.ts';
 // ── Membrane Keypad Logic (defined inline to avoid Rollup web-worker resolution issues) ────
 class KeypadLogic extends BaseComponent {
     constructor(id: string, manifest: any) {
@@ -81,6 +93,18 @@ export const LOGIC_REGISTRY: Record<string, any> = {
     'shift_register': ShiftRegisterLogic,
     'wokwi-membrane-keypad': KeypadLogic,
     'wokwi-analog-joystick': JoystickLogic,
+    'logic-not-gate': NotGateLogic,
+    'logic-and-gate': AndGateLogic,
+    'logic-or-gate': OrGateLogic,
+    'logic-nor-gate': NorGateLogic,
+    'logic-nand-gate': NandGateLogic,
+    'logic-xor-gate': XorGateLogic,
+    'logic-xnor-gate': XnorGateLogic,
+    'logic-mux-2to1': Mux2to1Logic,
+    'logic-d-flipflop': DFlipFlopLogic,
+    'logic-d-flipflop-r': DFlipFlopRLogic,
+    'logic-d-flipflop-dsr': DFlipFlopDsrLogic,
+    'logic-clock-generator': ClockGeneratorLogic,
 };
 
 // Per-type pin lists so every component's pins are registered correctly
@@ -99,6 +123,18 @@ export const COMPONENT_PINS: Record<string, { id: string }[]> = {
     'shift_register': [{ id: 'vcc' }, { id: 'gnd' }, { id: 'ser' }, { id: 'srclk' }, { id: 'rclk' }, { id: 'oe' }, { id: 'srclr' }, { id: 'q0' }, { id: 'q1' }, { id: 'q2' }, { id: 'q3' }, { id: 'q4' }, { id: 'q5' }, { id: 'q6' }, { id: 'q7' }, { id: 'q7s' }],
     'wokwi-membrane-keypad': [{ id: 'R1' }, { id: 'R2' }, { id: 'R3' }, { id: 'R4' }, { id: 'C1' }, { id: 'C2' }, { id: 'C3' }, { id: 'C4' }],
     'wokwi-analog-joystick': [{ id: 'GND' }, { id: '5V' }, { id: 'VRX' }, { id: 'VRY' }, { id: 'SW' }],
+    'logic-not-gate': [{ id: 'IN' }, { id: 'OUT' }],
+    'logic-and-gate': [{ id: 'IN1' }, { id: 'IN2' }, { id: 'OUT' }],
+    'logic-or-gate': [{ id: 'IN1' }, { id: 'IN2' }, { id: 'OUT' }],
+    'logic-nor-gate': [{ id: 'IN1' }, { id: 'IN2' }, { id: 'OUT' }],
+    'logic-nand-gate': [{ id: 'IN1' }, { id: 'IN2' }, { id: 'OUT' }],
+    'logic-xor-gate': [{ id: 'IN1' }, { id: 'IN2' }, { id: 'OUT' }],
+    'logic-xnor-gate': [{ id: 'IN1' }, { id: 'IN2' }, { id: 'OUT' }],
+    'logic-mux-2to1': [{ id: 'D0' }, { id: 'D1' }, { id: 'SEL' }, { id: 'OUT' }],
+    'logic-d-flipflop': [{ id: 'D' }, { id: 'CLK' }, { id: 'Q' }, { id: 'Qbar' }],
+    'logic-d-flipflop-r': [{ id: 'D' }, { id: 'CLK' }, { id: 'R' }, { id: 'Q' }, { id: 'Qbar' }],
+    'logic-d-flipflop-dsr': [{ id: 'D' }, { id: 'CLK' }, { id: 'S' }, { id: 'R' }, { id: 'Q' }, { id: 'Qbar' }],
+    'logic-clock-generator': [{ id: 'OUT' }],
 };
 
 export type AVRRunnerOptions = {

--- a/src/worker/execute.ts
+++ b/src/worker/execute.ts
@@ -15,11 +15,11 @@ import { SlidePotLogic } from '@openhw/emulator/src/components/wokwi-slide-poten
 import { PotentiometerLogic } from '@openhw/emulator/src/components/wokwi-potentiometer/logic.ts';
 import { ShiftRegisterLogic } from '@openhw/emulator/src/components/shift_register/logic.ts';
 import { JoystickLogic } from '@openhw/emulator/src/components/wokwi-analog-joystick/logic.ts';
-import { NotGateLogic } from '@openhw/emulator/src/components/logic-not-gate/logic.ts';
 import { AndGateLogic } from '@openhw/emulator/src/components/logic-and-gate/logic.ts';
 import { OrGateLogic } from '@openhw/emulator/src/components/logic-or-gate/logic.ts';
-import { NorGateLogic } from '@openhw/emulator/src/components/logic-nor-gate/logic.ts';
+import { NotGateLogic } from '@openhw/emulator/src/components/logic-not-gate/logic.ts';
 import { NandGateLogic } from '@openhw/emulator/src/components/logic-nand-gate/logic.ts';
+import { NorGateLogic } from '@openhw/emulator/src/components/logic-nor-gate/logic.ts';
 import { XorGateLogic } from '@openhw/emulator/src/components/logic-xor-gate/logic.ts';
 import { XnorGateLogic } from '@openhw/emulator/src/components/logic-xnor-gate/logic.ts';
 import { Mux2to1Logic } from '@openhw/emulator/src/components/logic-mux-2to1/logic.ts';
@@ -93,11 +93,11 @@ export const LOGIC_REGISTRY: Record<string, any> = {
     'shift_register': ShiftRegisterLogic,
     'wokwi-membrane-keypad': KeypadLogic,
     'wokwi-analog-joystick': JoystickLogic,
-    'logic-not-gate': NotGateLogic,
     'logic-and-gate': AndGateLogic,
     'logic-or-gate': OrGateLogic,
-    'logic-nor-gate': NorGateLogic,
+    'logic-not-gate': NotGateLogic,
     'logic-nand-gate': NandGateLogic,
+    'logic-nor-gate': NorGateLogic,
     'logic-xor-gate': XorGateLogic,
     'logic-xnor-gate': XnorGateLogic,
     'logic-mux-2to1': Mux2to1Logic,
@@ -123,11 +123,11 @@ export const COMPONENT_PINS: Record<string, { id: string }[]> = {
     'shift_register': [{ id: 'vcc' }, { id: 'gnd' }, { id: 'ser' }, { id: 'srclk' }, { id: 'rclk' }, { id: 'oe' }, { id: 'srclr' }, { id: 'q0' }, { id: 'q1' }, { id: 'q2' }, { id: 'q3' }, { id: 'q4' }, { id: 'q5' }, { id: 'q6' }, { id: 'q7' }, { id: 'q7s' }],
     'wokwi-membrane-keypad': [{ id: 'R1' }, { id: 'R2' }, { id: 'R3' }, { id: 'R4' }, { id: 'C1' }, { id: 'C2' }, { id: 'C3' }, { id: 'C4' }],
     'wokwi-analog-joystick': [{ id: 'GND' }, { id: '5V' }, { id: 'VRX' }, { id: 'VRY' }, { id: 'SW' }],
-    'logic-not-gate': [{ id: 'IN' }, { id: 'OUT' }],
     'logic-and-gate': [{ id: 'IN1' }, { id: 'IN2' }, { id: 'OUT' }],
     'logic-or-gate': [{ id: 'IN1' }, { id: 'IN2' }, { id: 'OUT' }],
-    'logic-nor-gate': [{ id: 'IN1' }, { id: 'IN2' }, { id: 'OUT' }],
+    'logic-not-gate': [{ id: 'IN' }, { id: 'OUT' }],
     'logic-nand-gate': [{ id: 'IN1' }, { id: 'IN2' }, { id: 'OUT' }],
+    'logic-nor-gate': [{ id: 'IN1' }, { id: 'IN2' }, { id: 'OUT' }],
     'logic-xor-gate': [{ id: 'IN1' }, { id: 'IN2' }, { id: 'OUT' }],
     'logic-xnor-gate': [{ id: 'IN1' }, { id: 'IN2' }, { id: 'OUT' }],
     'logic-mux-2to1': [{ id: 'D0' }, { id: 'D1' }, { id: 'SEL' }, { id: 'OUT' }],


### PR DESCRIPTION
All 12 logic gate component types were missing from LOGIC_REGISTRY and
COMPONENT_PINS in execute.ts, preventing the simulation worker from
instantiating them at runtime. This caused LEDs connected to logic gate
outputs to never illuminate, as no voltage was being propagated through
the circuit.

Components registered:
- Basic gates: AND, OR, NOT, NAND, NOR, XOR, XNOR
- Sequential logic: D Flip-Flop, D Flip-Flop with Reset, D Flip-Flop with Set/Reset
- Combinational: 2-to-1 MUX
- Clock Generator

Changes made in src/worker/execute.ts:
- Added 12 import statements for logic gate classes
- Added 12 entries to LOGIC_REGISTRY
- Added 13 entries to COMPONENT_PINS with correct pin definitions
- Resolved merge conflicts with remote branch (duplicate registrations in different order)
