### PR TITLE
fix:  pin hover logic, and ui alignment issues

### DIFF
--- a/src/pages/simulationpage/SimulatorPage.jsx
+++ b/src/pages/simulationpage/SimulatorPage.jsx
@@ -255,6 +255,22 @@ function syncNextIds(components, wires) {
 const autoConnectPowerRails = (newComp, existingComponents, currentWires) => {
   let newWires = [...currentWires];
 
+  const getPinX = (c, p) => {
+    if (!p) return 0;
+    if (p.x !== undefined) return p.x;
+    if (c.type.includes('pico')) {
+      const n = parseInt(p.id);
+      if (!isNaN(n)) return n <= 20 ? 0 : (c.w || 60);
+    }
+    return (c.w || 60) / 2;
+  };
+
+  const getPinY = (c, p) => {
+    if (!p) return 0;
+    if (p.y !== undefined) return p.y;
+    return (c.h || 60) / 2;
+  };
+
   const getBestPowerPins = (comp, bb) => {
     const pins = LOCAL_PIN_DEFS[comp.type] || [];
     const bbPins = LOCAL_PIN_DEFS[bb.type] || [];
@@ -299,21 +315,6 @@ const autoConnectPowerRails = (newComp, existingComponents, currentWires) => {
     const vccList = vccPins.length > 0 ? vccPins : [null];
     const gndList = gndPins.length > 0 ? gndPins : [null];
 
-    const getPinX = (c, p) => {
-      if (!p) return 0;
-      if (p.x !== undefined) return p.x;
-      if (c.type.includes('pico')) {
-        const n = parseInt(p.id);
-        if (!isNaN(n)) return n <= 20 ? 0 : (c.w || 60);
-      }
-      return (c.w || 60) / 2;
-    };
-    
-    const getPinY = (c, p) => {
-      if (!p) return 0;
-      if (p.y !== undefined) return p.y;
-      return (c.h || 60) / 2;
-    };
 
     vccList.forEach(vcc => {
       const vccX = vcc ? comp.x + getPinX(comp, vcc) : 0;
@@ -392,11 +393,14 @@ const autoConnectPowerRails = (newComp, existingComponents, currentWires) => {
         w.from === `${comp.id}:${pair.vcc.id}` || w.to === `${comp.id}:${pair.vcc.id}`
       );
       if (!alreadyWired) {
+        // Detect voltage type for wire color: orange for 3.3V, red for 5V
+        const vccIdDesc = ((pair.vcc.id || '') + ' ' + (pair.vcc.description || '')).toUpperCase();
+        const is3v3 = vccIdDesc.includes('3.3') || vccIdDesc.includes('3V3');
         newWires.push({
           id: `w${nextWireId++}`,
           from: `${comp.id}:${pair.vcc.id}`,
           to: `${bb.id}:${pair.bbVcc}`,
-          color: 'red',
+          color: is3v3 ? '#f97316' : 'red',
           isBelow: false,
           waypoints: makeCleanWaypoints(pair.vcc, pair.bbVcc)
         });

--- a/src/pages/simulationpage/TopToolbox.jsx
+++ b/src/pages/simulationpage/TopToolbox.jsx
@@ -1056,7 +1056,7 @@ function TopToolboxInternal(props) {
             style={{
               position: "absolute",
               top: "calc(100% + 8px)",
-              left: 0,
+              right: 0,
               width: 320,
               background: "var(--bg2)",
               border: "1px solid var(--border)",

--- a/src/pages/simulationpage/components/CanvasSceneLayer.jsx
+++ b/src/pages/simulationpage/components/CanvasSceneLayer.jsx
@@ -560,7 +560,13 @@ function CanvasSceneLayerBase({
                   const currentCat = getPinCategory(pin.id, pin.description, comp.type);
 
                   const isSuggested = startCat && currentCat && hasCategoryIntersection(startCat, currentCat) && !isWireStartPin;
-                  const isRelated = hoverCat && currentCat && hasCategoryIntersection(hoverCat, currentCat) && !isHovered;
+                  // Only highlight related pins for truly shared-purpose rails (GND, power).
+                  // Do NOT glow for broad GPIO categories (DIGITAL, ANALOG, PWM, etc.)
+                  // as it falsely implies the pins are interconnected.
+                  const SHARED_PURPOSE_CATS = ['GND', 'POWER', 'VIN'];
+                  const hoverHasShared = hoverCat && hoverCat.some(c => SHARED_PURPOSE_CATS.includes(c));
+                  const currentHasShared = currentCat && currentCat.some(c => SHARED_PURPOSE_CATS.includes(c));
+                  const isRelated = hoverHasShared && currentHasShared && hasCategoryIntersection(hoverCat, currentCat) && !isHovered;
 
                   const isHighlight = isWireStartPin || isHovered || isSuggested || isRelated || isSnapping;
                   const connectedWire = wires.find(w => w.from === pinStrRef || w.to === pinStrRef);
@@ -596,19 +602,26 @@ function CanvasSceneLayerBase({
                       onMouseLeave={() => setHoveredPin(null)}
                       onClick={e => onPinClick(e, comp.id, pin.id, pin.description || pin.id)}
                     >
-                      {isHovered && (
-                        <div style={{
-                          position: 'absolute', bottom: 18, left: '50%',
-                          transform: 'translateX(-50%)',
-                          background: '#111', color: '#fff',
-                          padding: '4px 8px', borderRadius: 4,
-                          fontSize: 10, whiteSpace: 'nowrap', zIndex: 9999,
-                          pointerEvents: 'none', border: '1px solid #444',
-                          boxShadow: '0 2px 5px rgba(0,0,0,0.5)',
-                        }}>
-                          {pin.description || pin.id}
-                        </div>
-                      )}
+                      {isHovered && (() => {
+                          let label = pin.description || pin.id;
+                          // Show voltage-specific labels for breadboard power rails
+                          if (comp.type.includes('breadboard')) {
+                            label = label.replace(/^top_vcc/, 'top_3.3v').replace(/^bottom_vcc/, 'bottom_5v');
+                          }
+                          return (
+                            <div style={{
+                              position: 'absolute', bottom: 18, left: '50%',
+                              transform: 'translateX(-50%)',
+                              background: '#111', color: '#fff',
+                              padding: '4px 8px', borderRadius: 4,
+                              fontSize: 10, whiteSpace: 'nowrap', zIndex: 9999,
+                              pointerEvents: 'none', border: '1px solid #444',
+                              boxShadow: '0 2px 5px rgba(0,0,0,0.5)',
+                            }}>
+                              {label}
+                            </div>
+                          );
+                        })()}
                     </div>
                   );
                 })}


### PR DESCRIPTION
- Move getPinX/Y to parent scope in SimulatorPage to fix ReferenceError crash
- Add voltage-specific labels (3.3V/5V) to breadboard power rail tooltips
- Restrict 'related pin' hover glow exclusively to shared-purpose categories (GND, POWER, VIN)
- Fix Connect popup CSS alignment preventing off-screen cropping