### PR TITLE
feat: Code/Blocks toggle, Blockly UX fixes, export improvements, dark mode fixes

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -53,6 +53,7 @@ import ComponentLab from './pages/simulationpage/ComponentLab.jsx';
 const GradingPage = React.lazy(() => import('./pages/GradingPage.jsx'));
 import MaintenancePage from './pages/MaintenancePage.jsx';
 import AboutUsNew from './pages/AboutUsNewPage.jsx';
+import ExamplesPage from './pages/ExamplesPage.jsx';
 import AuthSuccess from "./pages/auth/AuthSuccess.jsx";
 import VisitorTracker from "./components/VisitorTracker.jsx";
 
@@ -186,6 +187,7 @@ export default function App() {
                 {/* Public Routes */}
                 <Route path="/" element={<LandingPage />} />
                 <Route path="/about" element={<AboutUsNew />} />
+                <Route path="/examples" element={<ExamplesPage />} />
                 <Route path="/login" element={<UserLoginPage />} />
                 <Route
                   path="/signin"

--- a/src/components/BlocklyEditor.jsx
+++ b/src/components/BlocklyEditor.jsx
@@ -58,9 +58,9 @@ const GET_DIGITAL_PINS = () => {
     return Array.from({ length: 29 }, (_, i) => [i === 25 ? `GP25 (LED)` : `GP${i}`, String(i)])
   }
   return [
-    ['P0', '0'], ['P1', '1'], ['P2', '2'], ['P3', '3'], ['P4', '4'], ['P5', '5'],
-    ['P6', '6'], ['P7', '7'], ['P8', '8'], ['P9', '9'], ['P10', '10'],
-    ['P11', '11'], ['P12', '12'], ['P13', '13'],
+    ['D0', '0'], ['D1', '1'], ['D2', '2'], ['D3', '3'], ['D4', '4'], ['D5', '5'],
+    ['D6', '6'], ['D7', '7'], ['D8', '8'], ['D9', '9'], ['D10', '10'],
+    ['D11', '11'], ['D12', '12'], ['D13', '13'],
     ['A0', 'A0'], ['A1', 'A1'], ['A2', 'A2'], ['A3', 'A3'], ['A4', 'A4'], ['A5', 'A5'],
   ]
 }
@@ -1933,20 +1933,13 @@ export default function BlocklyEditor({ onExportCode, onChange, xml, onXmlChange
       {/* ── Toolbar ── */}
       <div style={{
         display: 'flex', alignItems: 'center',
-        gap: isMobile ? 6 : 8,
+        gap: isMobile ? 6 : 4,
         padding: isMobile ? '8px 12px' : '6px 10px',
         flexShrink: 0, background: tok.toolbar, borderBottom: `1px solid ${tok.border}`,
-        height: isMobile ? 48 : 'auto'
+        height: isMobile ? 48 : 'auto',
+        overflow: 'hidden', minWidth: 0,
       }}>
-        <span style={{
-          fontSize: 11,
-          fontWeight: isMobile ? 800 : 700,
-          textTransform: 'uppercase',
-          letterSpacing: isMobile ? '.1em' : '.08em',
-          color: tok.textMuted
-        }}>
-          {isMobile ? 'Blocks' : 'Block Editor'}
-        </span>
+
 
         <button
           type="button"
@@ -2034,15 +2027,13 @@ export default function BlocklyEditor({ onExportCode, onChange, xml, onXmlChange
           Use Blocks
         </button>
 
-        <div style={{ flex: 1 }} />
-
         <button
-          style={{ ...BTN, borderColor: tok.border, color: tok.textMuted, fontSize: 10, padding: '4px 8px' }}
+          style={{ ...BTN, borderColor: tok.border, color: tok.textMuted, fontSize: 10, padding: '4px 8px', marginLeft: 'auto', flexShrink: 0 }}
           onClick={() => importFileRef.current?.click()}
         >Import</button>
 
         <button
-          style={{ ...BTN, borderColor: tok.border, color: tok.textMuted, fontSize: 10, padding: '4px 8px' }}
+          style={{ ...BTN, borderColor: tok.border, color: tok.textMuted, fontSize: 10, padding: '4px 8px', flexShrink: 0 }}
           onClick={handleExportPng}
         >Export</button>
 
@@ -2056,7 +2047,8 @@ export default function BlocklyEditor({ onExportCode, onChange, xml, onXmlChange
             background: showCode ? 'rgba(0,255,255,0.05)' : 'transparent',
             fontSize: isMobile ? 10 : 11,
             padding: isMobile ? '4px 8px' : '3px 10px',
-            marginRight: isMobile ? 2 : 0
+            marginRight: isMobile ? 2 : 0,
+            flexShrink: 0,
           }}
           onClick={() => setShowCode(v => !v)}
         >Preview</button>
@@ -2070,7 +2062,8 @@ export default function BlocklyEditor({ onExportCode, onChange, xml, onXmlChange
             fontWeight: 800,
             fontSize: isMobile ? 11 : 11,
             padding: isMobile ? '5px 12px' : '3px 10px',
-            boxShadow: isMobile ? '0 2px 8px rgba(0,255,255,0.2)' : 'none'
+            boxShadow: isMobile ? '0 2px 8px rgba(0,255,255,0.2)' : 'none',
+            flexShrink: 0,
           }}
           onClick={handleExport} disabled={loadStatus !== 'ready'}
         >Use Code</button>

--- a/src/components/common/ClassroomSidebar.jsx
+++ b/src/components/common/ClassroomSidebar.jsx
@@ -10,7 +10,7 @@ export default function ClassroomSidebar({
 }) {
   const [theme, setTheme] = useState(
     () =>
-      localStorage.getItem("openhw_theme") ||
+      localStorage.getItem("theme") ||
       document.documentElement.getAttribute("data-theme") ||
       "light",
   );
@@ -25,7 +25,7 @@ export default function ClassroomSidebar({
     setTheme((prev) => {
       const next = prev === "dark" ? "light" : "dark";
       document.documentElement.setAttribute("data-theme", next);
-      localStorage.setItem("openhw_theme", next);
+      localStorage.setItem("theme", next);
       return next;
     });
   };

--- a/src/index.css
+++ b/src/index.css
@@ -2813,8 +2813,8 @@ body {
   bottom: 48px;
   left: 0;
   width: 100%;
-  background: #fff;
-  border: 1px solid #dbe6f2;
+  background: var(--bg2);
+  border: 1px solid var(--border);
   border-radius: 10px;
   padding: 6px;
   box-shadow: 0 16px 32px rgba(15, 23, 42, 0.1);
@@ -2827,7 +2827,7 @@ body {
   text-align: left;
   border-radius: 8px;
   padding: 8px;
-  color: #334155;
+  color: var(--text);
   font-size: 0.82rem;
   cursor: pointer;
 }

--- a/src/pages/ExamplesPage.jsx
+++ b/src/pages/ExamplesPage.jsx
@@ -1,0 +1,294 @@
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { PROJECTS } from '../services/gamification/ProjectsConfig.js';
+
+const EXAMPLES_BASE_URL =
+  import.meta.env.VITE_EXAMPLES_BASE_URL ||
+  (import.meta.env.DEV ? 'https://openhw-studio.fossee.in/examples' : '/examples');
+
+const DOCS_URL =
+  import.meta.env.VITE_DOCS_URL || 'https://openhw-studio.fossee.in/docs/';
+
+const DIFFICULTY = {
+  'led-blink':          'Beginner',
+  'rgb-led':            'Beginner',
+  'buzzer':             'Beginner',
+  'potentiometer':      'Beginner',
+  'button-debounce':    'Beginner',
+  'ldr':                'Intermediate',
+  'servo-motor':        'Intermediate',
+  'temperature-sensor': 'Intermediate',
+  'led-strip':          'Advanced',
+  'dc-motor':           'Intermediate',
+};
+
+const CATEGORY = {
+  'led-blink':          'Output',
+  'rgb-led':            'Output',
+  'buzzer':             'Output',
+  'potentiometer':      'Input',
+  'button-debounce':    'Input',
+  'ldr':                'Sensor',
+  'servo-motor':        'Motor',
+  'temperature-sensor': 'Sensor',
+  'led-strip':          'Output',
+  'dc-motor':           'Motor',
+};
+
+const ICONS = {
+  'led-blink':          '💡',
+  'rgb-led':            '🌈',
+  'buzzer':             '🔊',
+  'potentiometer':      '🎛️',
+  'button-debounce':    '🔘',
+  'ldr':                '☀️',
+  'servo-motor':        '🦾',
+  'temperature-sensor': '🌡️',
+  'led-strip':          '✨',
+  'dc-motor':           '⚙️',
+};
+
+const XP = {
+  'led-blink':          100,
+  'rgb-led':            150,
+  'buzzer':             150,
+  'potentiometer':      175,
+  'button-debounce':    200,
+  'ldr':                200,
+  'servo-motor':        225,
+  'temperature-sensor': 250,
+  'led-strip':          300,
+  'dc-motor':           225,
+};
+
+const ALL_CATEGORIES = ['All', 'Output', 'Input', 'Sensor', 'Motor'];
+const ALL_DIFFICULTIES = ['All', 'Beginner', 'Intermediate', 'Advanced'];
+
+function ExampleCard({ p }) {
+  const navigate = useNavigate();
+  const [imgErr, setImgErr] = useState(false);
+  const [imgOk, setImgOk]   = useState(false);
+  const diff = DIFFICULTY[p.slug] || 'Beginner';
+  const isBeginner = diff === 'Beginner';
+  const isAdvanced = diff === 'Advanced';
+
+  return (
+    <div
+      className="feature-card"
+      style={{ cursor: 'pointer', textAlign: 'left', padding: 0, overflow: 'hidden', display: 'flex', flexDirection: 'column' }}
+      onClick={() => navigate(`/${p.slug}/guide`)}
+    >
+      <div style={{
+        height: 140,
+        background: 'var(--bg, #0a0e1a)',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        overflow: 'hidden',
+        position: 'relative',
+        flexShrink: 0,
+      }}>
+        {!imgErr && (
+          <img
+            src={`${EXAMPLES_BASE_URL}/${p.slug}/circuit.png`}
+            alt={p.title}
+            onLoad={() => setImgOk(true)}
+            onError={() => setImgErr(true)}
+            style={{
+              width: '100%', height: '100%', objectFit: 'contain',
+              padding: 10, opacity: imgOk ? 1 : 0, transition: 'opacity .3s',
+            }}
+          />
+        )}
+        {!imgOk && !imgErr && (
+          <span style={{ position: 'absolute', fontSize: 32, opacity: 0.15 }}>{ICONS[p.slug] || '⚡'}</span>
+        )}
+        {imgErr && (
+          <span style={{ fontSize: 32, opacity: 0.25 }}>{ICONS[p.slug] || '🔌'}</span>
+        )}
+        <span style={{
+          position: 'absolute', top: 8, right: 8,
+          fontSize: 10, fontWeight: 700, padding: '2px 7px', borderRadius: 99,
+          background: 'rgba(0,0,0,0.55)', backdropFilter: 'blur(4px)',
+          color: 'rgba(255,255,255,0.65)', border: '1px solid rgba(255,255,255,0.1)',
+        }}>
+          {CATEGORY[p.slug]}
+        </span>
+      </div>
+
+      <div style={{ padding: '14px 16px 16px', display: 'flex', flexDirection: 'column', flex: 1 }}>
+        <div className="feature-icon" style={{ fontSize: 20, marginBottom: 6 }}>{ICONS[p.slug] || '⚡'}</div>
+        <h3 style={{ marginBottom: 3, fontSize: 15 }}>{p.title}</h3>
+        <p style={{ margin: '0 0 10px', fontSize: 12, opacity: 0.55, lineHeight: 1.4 }}>{p.subtitle}</p>
+
+        <div style={{ display: 'flex', gap: 8, alignItems: 'center', marginBottom: 14 }}>
+          <span style={{
+            fontSize: 11, fontWeight: 700, padding: '3px 8px', borderRadius: 5,
+            background: isBeginner ? 'rgba(34,197,94,.15)' : isAdvanced ? 'rgba(239,68,68,.15)' : 'rgba(251,191,36,.15)',
+            color: isBeginner ? '#22c55e' : isAdvanced ? '#ef4444' : '#fbbf24',
+            border: `1px solid ${isBeginner ? 'rgba(34,197,94,.3)' : isAdvanced ? 'rgba(239,68,68,.3)' : 'rgba(251,191,36,.3)'}`,
+          }}>
+            {diff}
+          </span>
+          <span style={{ fontSize: 12, fontWeight: 700, color: '#fbbf24' }}>+{XP[p.slug] || 100} XP</span>
+        </div>
+
+        <div
+          style={{ display: 'flex', gap: 8, marginTop: 'auto' }}
+          onClick={e => e.stopPropagation()}
+        >
+          <button
+            className="btn btn-outline"
+            style={{ flex: 1, fontSize: 12 }}
+            onClick={() => navigate(`/${p.slug}/guide`)}
+          >
+            📖 Guide
+          </button>
+          <button
+            className="btn btn-primary"
+            style={{ flex: 1, fontSize: 12 }}
+            onClick={() => navigate(`/${p.slug}/demo`)}
+          >
+            ▶ Try it
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default function ExamplesPage() {
+  const navigate = useNavigate();
+  const [search, setSearch]       = useState('');
+  const [filterCat, setFilterCat] = useState('All');
+  const [filterDiff, setFilterDiff] = useState('All');
+  const [theme, setTheme] = useState(
+  () => localStorage.getItem('theme') || 'dark'
+);
+
+const toggleTheme = () => {
+  const next = theme === 'dark' ? 'light' : 'dark';
+  setTheme(next);
+  document.documentElement.setAttribute('data-theme', next);
+  localStorage.setItem('theme', next);
+};
+
+
+  const filtered = PROJECTS.filter(p => {
+    const q = search.toLowerCase();
+    const matchSearch = !q || p.title.toLowerCase().includes(q) || (p.subtitle || '').toLowerCase().includes(q);
+    const matchCat  = filterCat  === 'All' || CATEGORY[p.slug]   === filterCat;
+    const matchDiff = filterDiff === 'All' || DIFFICULTY[p.slug] === filterDiff;
+    return matchSearch && matchCat && matchDiff;
+  });
+
+  return (
+    <div className="landing">
+      <nav className="nav">
+        <div className="nav-brand">
+          <img src="/logo-Photoroom.png" alt="OpenHW-Studio" className="brand-logo brand-logo--nav" />
+        </div>
+        <div className="nav-actions">
+          <button className="btn btn-ghost" onClick={() => navigate('/')}>← Home</button>
+          <button className="btn btn-ghost" onClick={() => navigate('/about')}>About Us</button>
+          <button className="btn btn-ghost" onClick={toggleTheme} title="Toggle Dark/Light Mode">
+  {theme === 'dark' ? '☀️ Light' : '🌙 Dark'}
+</button>
+          <button className="btn btn-primary" onClick={() => navigate('/simulator')}>▶ Try Simulator</button>
+        </div>
+      </nav>
+
+      <div style={{
+        textAlign: 'center',
+        padding: '2rem 1.5rem 1.5rem',
+        borderBottom: '1px solid rgba(255,255,255,0.06)',
+      }}>
+        <div className="hero-badge" style={{ marginBottom: '0.75rem' }}>📂 {PROJECTS.length} Project Examples</div>
+        <h1 className="hero-title" style={{ fontSize: 'clamp(1.6rem, 4vw, 2.4rem)', marginBottom: '0.5rem' }}>
+          Learn by doing. <span className="gradient-text">Pick a project.</span>
+        </h1>
+        <p style={{ color: 'var(--text2)', fontSize: 14, marginBottom: '1.25rem' }}>
+          Pre-built circuits and guided walkthroughs — no login required.
+        </p>
+
+        <div style={{ display: 'flex', gap: 10, justifyContent: 'center', alignItems: 'center', flexWrap: 'wrap' }}>
+          <input
+            type="text"
+            placeholder="Search examples…"
+            value={search}
+            onChange={e => setSearch(e.target.value)}
+            style={{
+              background: 'rgba(255,255,255,0.06)',
+              border: '1px solid rgba(0, 0, 0, 0.57)',
+              borderRadius: 10,
+              padding: '8px 16px',
+              fontSize: 13,
+              color: 'var(--text)',
+              outline: 'none',
+              width: 220,
+              fontFamily: 'inherit',
+            }}
+          />
+
+          <div style={{ display: 'flex', gap: 5, flexWrap: 'wrap', justifyContent: 'center' }}>
+            {ALL_CATEGORIES.map(c => (
+              <button
+                key={c}
+                onClick={() => setFilterCat(c)}
+                className={filterCat === c ? 'btn btn-primary' : 'btn btn-ghost'}
+                style={{ padding: '5px 13px', fontSize: 12, borderRadius: 99 }}
+              >
+                {c}
+              </button>
+            ))}
+          </div>
+
+          <div style={{ display: 'flex', gap: 5, flexWrap: 'wrap', justifyContent: 'center' }}>
+            {ALL_DIFFICULTIES.map(d => (
+              <button
+                key={d}
+                onClick={() => setFilterDiff(d)}
+                className={filterDiff === d ? 'btn btn-primary' : 'btn btn-ghost'}
+                style={{ padding: '5px 13px', fontSize: 12, borderRadius: 99 }}
+              >
+                {d}
+              </button>
+            ))}
+          </div>
+        </div>
+      </div>
+
+      <section className="features" style={{ paddingTop: '2rem' }}>
+        {filtered.length === 0 ? (
+          <div style={{ textAlign: 'center', padding: '60px 0', color: 'var(--text2)' }}>
+            <div style={{ fontSize: 40, marginBottom: 12 }}>🔍</div>
+            <p>No examples match your filters.</p>
+            <button
+              className="btn btn-ghost"
+              style={{ marginTop: 12 }}
+              onClick={() => { setSearch(''); setFilterCat('All'); setFilterDiff('All'); }}
+            >
+              Clear filters
+            </button>
+          </div>
+        ) : (
+          <div className="features-grid">
+            {filtered.map(p => <ExampleCard key={p.slug} p={p} />)}
+          </div>
+        )}
+      </section>
+
+      <footer className="footer">
+        <div className="footer-brand">
+          <img src="/logo-Photoroom.png" alt="OpenHW-Studio" className="brand-logo brand-logo--footer" />
+        </div>
+        <p>Open Source Hardware Simulation &amp; Learning Platform</p>
+        <div className="footer-links">
+          <a href="https://github.com/OpenHW-Studio/" target="_blank" rel="noopener noreferrer">GitHub</a>
+          <a href={DOCS_URL} target="_blank" rel="noopener noreferrer">Documentation</a>
+          <a href="/">Home</a>
+        </div>
+      </footer>
+    </div>
+  );
+}

--- a/src/pages/LandingPage.jsx
+++ b/src/pages/LandingPage.jsx
@@ -43,7 +43,9 @@ export default function LandingPage() {
           <button className="btn btn-ghost" onClick={() => navigate("/about")}>
             About Us
           </button>
-
+<button className="btn btn-ghost" onClick={() => navigate("/examples")}>
+            Examples
+          </button>
           <button
             className="btn btn-ghost"
             onClick={toggleTheme}
@@ -310,7 +312,7 @@ export default function LandingPage() {
           <a href={DOCS_URL} target="_blank" rel="noopener noreferrer">
             Documentation
           </a>
-          <a href="#">Examples</a>
+          <a href="/examples">Examples</a>
         </div>
       </footer>
     </div>

--- a/src/pages/auth/AuthSuccess.jsx
+++ b/src/pages/auth/AuthSuccess.jsx
@@ -25,10 +25,17 @@ export default function AuthSuccess() {
 
         // Fetch user profile from backend
         const data = await fetchProfile();
+
+        let defaultRedirect = "/user/dashboard";
+        if (data.user?.role === "student") {
+          defaultRedirect = "/student/dashboard";
+        } else if (data.user?.role === "teacher") {
+          defaultRedirect = "/teacher/dashboard";
+        }
         
         if (data && data.user) {
           // Check if there was a saved redirect destination
-          const redirectPath = localStorage.getItem("authRedirectPath") || "/user/dashboard";
+          const redirectPath = localStorage.getItem("authRedirectPath") || defaultRedirect;
           // Delay removal so StrictMode's second execution can still read it
           setTimeout(() => localStorage.removeItem("authRedirectPath"), 1000);
           

--- a/src/pages/mobileui/SimulatorPage.jsx
+++ b/src/pages/mobileui/SimulatorPage.jsx
@@ -8058,7 +8058,11 @@ useEffect(() => {
 
       // 4. Append metadata bytes after PNG IEND → still renders fine in all image viewers
       const dateStr = new Date().toISOString().slice(0, 16).replace('T', '_').replace(':', '-').replace(':', '-');
-      const filename = `circuit_${board}_${dateStr}.png`;
+      const safeName = (currentProjectName && currentProjectName !== "Untitled")
+  ? currentProjectName.replace(/[^a-z0-9_\-]/gi, "_")
+  : `circuit_${board}`;
+      const filename = `${safeName}_${dateStr}.png`;
+
       out.toBlob(async (blob) => {
         const t_blob_start = performance.now();
         const pngBuf = await blob.arrayBuffer();

--- a/src/pages/simulationpage/SimulatorPage.jsx
+++ b/src/pages/simulationpage/SimulatorPage.jsx
@@ -12608,14 +12608,13 @@ loadDemoProject();
           setShowAutofix={setShowAutofix}
           showShortcuts={showShortcuts}
           setShowShortcuts={setShowShortcuts}
+          useBlocklyCode={useBlocklyCode}
+          setUseBlocklyCode={setUseBlocklyCode}
           onStartTour={() => {
             localStorage.removeItem("openhw-tour-completed");
             setShowTour(true);
           }}
           returnTo={location.search.includes("returnTo") ? new URLSearchParams(location.search).get("returnTo") : null}
-          navigate={navigate}
-          components={components}
-          wires={wires}
           code={code}
         />
 

--- a/src/pages/simulationpage/TopToolbox.jsx
+++ b/src/pages/simulationpage/TopToolbox.jsx
@@ -422,6 +422,8 @@ function TopToolboxInternal(props) {
     returnTo,
     navigate,
     code,
+    useBlocklyCode,
+    setUseBlocklyCode,
   } = props;
 
    const viewPanelRef = useRef(null);
@@ -493,9 +495,18 @@ function TopToolboxInternal(props) {
     },
     { label: "Import", onClick: () => importFileRef.current?.click() },
     { label: "Save", shortcut: "Ctrl+S", onClick: handleSave },
+    {
+      label: "Export",
+      submenu: [
+        { label: "PNG", onClick: downloadPng },
+        { label: "JSON", onClick: downloadSimulationJson },
+      ],
+    },
     { label: "Make a copy", onClick: () => handleSave() }, // Placeholder for copy
     { type: "separator" },
-    { label: "Save Local Copy", onClick: handleBackupWorkflow },
+    { label: "Save Local Copy (ZIP)", onClick: handleBackupWorkflow },
+    { type: "separator" },
+    { label: "📂 Examples Gallery", onClick: () => navigate("/examples") },
   ];
 
   const toolMenuItems = [
@@ -508,13 +519,6 @@ function TopToolboxInternal(props) {
     },
     { label: "Alignment Lab", onClick: () => navigate("/alignment-lab") },
     { type: "separator" },
-    {
-      label: "Export",
-      submenu: [
-        { label: "PNG", onClick: downloadPng },
-        { label: "JSON", onClick: downloadSimulationJson },
-      ],
-    },
     { type: "separator" },
     { label: "Connect Hardware", onClick: () => setShowConnectPanel(true) },
   ];
@@ -684,7 +688,7 @@ function TopToolboxInternal(props) {
         </div>
       </div>
 
-      <div className="flex items-center gap-2 flex-1 flex-wrap">
+      <div className="flex items-center gap-2 flex-1 flex-wrap" style={{ minWidth: 0, overflowX: 'auto' }}>
         {/* RUN button */}
         <Btn
           color={
@@ -819,6 +823,43 @@ function TopToolboxInternal(props) {
             )}
           </Btn>
         )}
+
+        {/* Code / Blocks toggle */}
+        <div
+  onClick={() => setUseBlocklyCode(!useBlocklyCode)}
+  title={useBlocklyCode ? 'Currently running Blocks — click to switch to Code' : 'Currently running Code — click to switch to Blocks'}
+  style={{
+    display: 'flex',
+    alignItems: 'center',
+    gap: 0,
+    borderRadius: 8,
+    border: '1px solid var(--border)',
+    overflow: 'hidden',
+    cursor: 'pointer',
+    flexShrink: 0,
+    fontSize: 12,
+    fontWeight: 700,
+    userSelect: 'none',
+  }}
+>
+  <div style={{
+    padding: '5px 11px',
+    background: !useBlocklyCode ? 'var(--accent)' : 'transparent',
+    color: !useBlocklyCode ? '#000' : 'var(--text3)',
+    transition: 'all 0.15s',
+  }}>
+    &lt;/&gt; Code
+  </div>
+  <div style={{
+    padding: '5px 11px',
+    background: useBlocklyCode ? 'var(--accent)' : 'transparent',
+    color: useBlocklyCode ? '#000' : 'var(--text3)',
+    transition: 'all 0.15s',
+  }}>
+    ⬡ Blocks
+  </div>
+</div>
+
 
         {assessmentMode && (
           <Btn

--- a/src/pages/student/StudentDashboard.jsx
+++ b/src/pages/student/StudentDashboard.jsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useState } from 'react'
 import { useLocation, useNavigate } from 'react-router-dom'
-import { BookOpen, ClipboardCheck, Home, Monitor, X } from 'lucide-react'
+import { BookOpen, ClipboardCheck, Home, Monitor, X, User } from 'lucide-react'
 import { useAuth } from "../../context/AuthContext.jsx";
 import { useGamification } from "../../context/GamificationContext.jsx";
 import { PROJECTS } from "../../services/gamification/ProjectsConfig.js";
@@ -190,7 +190,8 @@ export default function StudentDashboard() {
   const sidebarLinks = [
     { key: 'home', label: 'Dashboard', icon: Home, isActive: true, onClick: () => {} },
     { key: 'simulator', label: 'Open Simulator', icon: Monitor, isActive: false, onClick: () => navigate('/simulator') },
-    { key: 'join', label: 'Join class', icon: BookOpen, isActive: false, onClick: handleOpenJoinModal }
+    { key: 'join', label: 'Join New Class', icon: BookOpen, isActive: false, onClick: handleOpenJoinModal },
+    { key: 'user-dash', label: 'Go to User Dashboard', icon: User, isActive: false, onClick: () => navigate('/user/dashboard') }
   ]
 
   const handlePasteCode = async () => {
@@ -297,7 +298,7 @@ export default function StudentDashboard() {
 
               {!loadingDashboard && !dashboardError && classrooms.length === 0 ? (
                 <div className="empty-state">
-                  <div className="empty-icon">??</div>
+                  <div className="empty-icon"></div>
                   <p>You have not joined any classes yet.</p>
                   <button type="button" className="btn btn-primary" onClick={handleOpenJoinModal}>
                     Join with class code

--- a/src/pages/user/UserDashboard.jsx
+++ b/src/pages/user/UserDashboard.jsx
@@ -1,13 +1,13 @@
 import { useEffect, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
-import { Home, Monitor, Settings } from 'lucide-react'
+import { Home, Monitor, Settings, GraduationCap } from 'lucide-react'
 import { useAuth } from '../../context/AuthContext.jsx'
 import ClassroomSidebar from '../../components/common/ClassroomSidebar.jsx'
 
 const sidebarLinks = [
   { key: 'home', label: 'Home', icon: Home },
   { key: 'simulator', label: 'Open Simulator', icon: Monitor },
-  { key: 'settings', label: 'Settings', icon: Settings }
+  { key: 'student-dash', label: 'Go to Student Dashboard', icon: GraduationCap }
 ]
 
 export default function UserDashboard() {
@@ -26,6 +26,8 @@ export default function UserDashboard() {
     isActive: item.key === 'home',
     onClick: () => {
       if (item.key === 'simulator') navigate('/simulator')
+      if (item.key === 'student-dash') navigate('/student/dashboard') // <-- Add this line
+
     }
   }))
 

--- a/src/worker/runners/avr-runner.ts
+++ b/src/worker/runners/avr-runner.ts
@@ -1225,6 +1225,7 @@ export class AVRRunner {
                         const p4 = (pindVal >> 4) & 1;
                         const p5 = (pindVal >> 5) & 1;
                         console.log(`[repropagate MUX] D0=${d0} D1=${d1} SEL=${sel} OUT=${outV} d0High=${inst.getPinVoltage('D0')>=2.5} d1High=${inst.getPinVoltage('D1')>=2.5} selHigh=${inst.getPinVoltage('SEL')>=2.5} stateOut=${inst.state?.outputHigh} PIND2=${p2} PIND3=${p3} PIND4=${p4} PIND5=${p5} pins=${Object.keys(inst.pins).join(',')}`);
+                    }
                 } else if (inst.type.includes('hc-sr04')) {
                     if (inst.pins['ECHO']) {
                         updateOopPin('ECHO', inst.pins['ECHO'].voltage, compId);


### PR DESCRIPTION
- Added a persistent Code/Blocks pill toggle in the simulator top bar for easy nav & use, better UX.
- Fixed the Blockly toolbar overflow that was cutting off buttons on the Blocks tab (right side).
- Fixed repeat_times block to use an inline number field instead of requiring a drag-in math block (edge cases exist).
- Renamed D0-D13 pins correctly (instead of og incorrect, non-Arduino compatible naming system).
- Moved Export into the File menu and made it accessible, fixed PNG export filename to use the current project name, and fixed dark mode sidebar link colors and Google OAuth redirect.